### PR TITLE
feat: upgrade GitHub Actions to latest pinned versions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,9 +12,9 @@ jobs:
         node-version: [22.14.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6.2.0
       with:
         node-version: ${{ matrix.node-version }}
     - name: npm install, build, and test


### PR DESCRIPTION
- Upgrade actions/checkout from v4 to v6.0.2
- Upgrade actions/setup-node from v4 to v6.2.0
- jakejarvis/s3-sync-action already at latest (v0.5.1)